### PR TITLE
Merge `dev` with `main`

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -23,7 +23,7 @@ coef.bolasso <- function(object, select = c("lambda.min", "lambda.1se"), ...) {
 predict.bolasso <- function(object, new.data, select = c("min", "1se"), ...) {
   varnames <- attributes(object)$varnames
   implement <- attributes(object)$implement
-  form <- attributes(object)$call$form
+  form <- eval(attributes(object)$call$form)
   if (!is.null(form)) {
     new.data <- model_matrix(form = form, data = new.data, prediction = TRUE)$x
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,7 @@ formula_lhs <- function(form) {
     error = function(e) stop("Invalid formula", call. = FALSE)
   )
   if (length(form) < 3) stop("Formula is missing LHS variable", call. = FALSE)
-  deparse(form[[2]])
+  deparse(form[[2]], width.cutoff = 500L)
 }
 
 formula_rhs <- function(form) {
@@ -21,9 +21,9 @@ formula_rhs <- function(form) {
     error = function(e) stop("Invalid formula", call. = FALSE)
   )
   if (length(form) < 3) {
-    deparse(form[[2]])
+    deparse(form[[2]], width.cutoff = 500L)
   } else {
-    deparse(form[[3]])
+    deparse(form[[3]], width.cutoff = 500L)
   }
 }
 


### PR DESCRIPTION
Deals with the following issues/enhancements:
- Parallelizes `predict` and `coef` methods.
- Fixes `deparse` issue where long formulas were getting split into multi-element character vectors.
- Wraps formula with `eval` so that, when passed a formula indirectly, `predict` can find it.